### PR TITLE
Update about.md - Remove Claude Code role reference

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -1,5 +1,4 @@
 - Writing GPU kernels, breaking LLMs into atomic pieces and making them go fast.
-- Post-training Claude models for Claude Code at Alignerr.
 - Amateur bassist.
 - Getting into endurance - mostly cycling.
 - Huge fan of all things automotive. Weekends glued to motorsport races.


### PR DESCRIPTION
## Summary
Removed outdated professional experience reference from the about page.

## Changes
- Removed the line mentioning post-training work on Claude models at Alignerr

## Details
This appears to be a resume/bio update removing a previous role or position that is no longer current or relevant to include in the about section.

https://claude.ai/code/session_01UVyjNxW6xuVie5GprpNbxq