### PR TITLE
Switch site font to Reddit Mono

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Reddit+Mono:wght@400;700&display=swap");
 
 @tailwind base;
 @tailwind components;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,8 +8,8 @@ const config: Config = {
   ],
   theme: {
     fontFamily: {
-      sans: ['"JetBrains Mono"', 'monospace'],
-      mono: ['"JetBrains Mono"', 'monospace'],
+      sans: ['"Reddit Mono"', 'monospace'],
+      mono: ['"Reddit Mono"', 'monospace'],
     },
     extend: {
       backgroundImage: {


### PR DESCRIPTION
### Motivation
- Replace the current JetBrains Mono font with Reddit Mono so the site uses the requested font family across styles and Tailwind utilities.

### Description
- Replace the Google Fonts import in `styles/globals.css` to load `Reddit Mono` instead of `JetBrains Mono`.
- Update `tailwind.config.ts` to set both `fontFamily.sans` and `fontFamily.mono` to `['"Reddit Mono"', 'monospace']` so Tailwind utility classes use the new font.

### Testing
- Ran `pnpm lint` which completed with no ESLint warnings or errors.
- Ran `pnpm build` which compiled the app and generated static pages successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38b87f6c94832bb0d099950a51e15d)